### PR TITLE
Handle null prompts in chat service

### DIFF
--- a/src/main/java/org/abosk/openaiclient/service/OpenAiService.java
+++ b/src/main/java/org/abosk/openaiclient/service/OpenAiService.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 public class OpenAiService {
@@ -33,7 +34,13 @@ public class OpenAiService {
 
     public String chat(String prompt) {
         log.info("🟡 Prompt original: [{}]", prompt);
-        String normalizedPrompt = prompt.trim().replaceAll("\\s+", " ");
+        if (prompt == null) {
+            log.warn("⚠️ Prompt is null. Using empty string as fallback");
+        }
+        String normalizedPrompt = Optional.ofNullable(prompt)
+                .orElse("")
+                .trim()
+                .replaceAll("\\s+", " ");
         log.info("🟢 Prompt normalized: [{}]", normalizedPrompt);
 
         OpenAiRequest request = new OpenAiRequest(


### PR DESCRIPTION
## Summary
- handle `null` prompts in `OpenAiService.chat`
- log warning when prompt is `null`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684004adb9fc8329913946281309bdee